### PR TITLE
Add Card Adding/Removing Functionality with a Patch rather than a Diff

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="C:/Users/Davis/git/_lib/desktop-1.0.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Davis/git/_lib/ModTheSpire.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Davis/git/_lib/ModTheSpireLib.jar"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ hs_err_pid*
 .idea/workspace.xml
 src/main/java/com/megacrit/**/*.java
 target/
+/bin/

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>BaseMod</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/src/main/java/basemod/BaseMod.java
+++ b/src/main/java/basemod/BaseMod.java
@@ -204,7 +204,6 @@ public class BaseMod {
     // red remove -
     public static ArrayList<AbstractCard> getRedCardsToRemove() {
     	ArrayList<AbstractCard> redToRemove = new ArrayList<AbstractCard>();
-    	redToRemove.add(new Headbutt());
     	return redToRemove;
     }
     

--- a/src/main/java/basemod/BaseMod.java
+++ b/src/main/java/basemod/BaseMod.java
@@ -11,6 +11,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.AbstractCard.CardColor;
 import com.megacrit.cardcrawl.cards.red.Headbutt;
 import com.megacrit.cardcrawl.characters.AbstractPlayer.PlayerClass;
 import com.megacrit.cardcrawl.core.Settings;
@@ -63,6 +64,15 @@ public class BaseMod {
     private static ArrayList<PostCreateStartingDeckSubscriber> postCreateStartingDeckSubscribers;
     private static ArrayList<PostCreateStartingRelicsSubscriber> postCreateStartingRelicsSubscribers;
     
+    private static ArrayList<AbstractCard> redToAdd;
+    private static ArrayList<String> redToRemove;
+    private static ArrayList<AbstractCard> greenToAdd;
+    private static ArrayList<String> greenToRemove;
+    private static ArrayList<AbstractCard> colorlessToAdd;
+    private static ArrayList<String> colorlessToRemove;
+    private static ArrayList<AbstractCard> curseToAdd;
+    private static ArrayList<String> curseToRemove;
+    
     public static DevConsole console;
     public static Gson gson;
     public static boolean modSettingsUp = false;
@@ -89,6 +99,7 @@ public class BaseMod {
         initializeGson();
         initializeTypeMaps();
         initializeSubscriptions();
+        initializeCardLists();
 
         console = new DevConsole();
         
@@ -156,6 +167,18 @@ public class BaseMod {
         postCreateStartingRelicsSubscribers = new ArrayList<>();
     }
     
+    // initializeCardLists -
+    private static void initializeCardLists() {
+    	redToAdd = new ArrayList<>();
+    	redToRemove = new ArrayList<>();
+    	greenToAdd = new ArrayList<>();
+    	greenToRemove = new ArrayList<>();
+    	colorlessToAdd = new ArrayList<>();
+    	colorlessToRemove = new ArrayList<>();
+    	curseToAdd = new ArrayList<>();
+    	curseToRemove = new ArrayList<>();
+    }
+    
     //
     // Mod badges
     //
@@ -198,43 +221,78 @@ public class BaseMod {
     
     // red add -
     public static ArrayList<AbstractCard> getRedCardsToAdd() {
-    	return new ArrayList<AbstractCard>();
+    	return redToAdd;
     }
     
     // red remove -
-    public static ArrayList<AbstractCard> getRedCardsToRemove() {
-    	ArrayList<AbstractCard> redToRemove = new ArrayList<AbstractCard>();
+    public static ArrayList<String> getRedCardsToRemove() {
     	return redToRemove;
     }
     
     // green add -
     public static ArrayList<AbstractCard> getGreenCardsToAdd() {
-    	return new ArrayList<AbstractCard>();
+    	return greenToAdd;
     }
     
     // green remove -
-    public static ArrayList<AbstractCard> getGreenCardsToRemove() {
-    	return new ArrayList<AbstractCard>();
+    public static ArrayList<String> getGreenCardsToRemove() {
+    	return greenToRemove;
     }
     
     // colorless add -
     public static ArrayList<AbstractCard> getColorlessCardsToAdd() {
-    	return new ArrayList<AbstractCard>();
+    	return colorlessToAdd;
     }
     
     // colorless remove -
-    public static ArrayList<AbstractCard> getColorlessCardsToRemove() {
-    	return new ArrayList<AbstractCard>();
+    public static ArrayList<String> getColorlessCardsToRemove() {
+    	return colorlessToRemove;
     }
     
     // curse add -
     public static ArrayList<AbstractCard> getCurseCardsToAdd() {
-    	return new ArrayList<AbstractCard>();
+    	return curseToAdd;
     }
     
     // curse remove -
-    public static ArrayList<AbstractCard> getCurseCardsToRemove() {
-    	return new ArrayList<AbstractCard>();
+    public static ArrayList<String> getCurseCardsToRemove() {
+    	return curseToRemove;
+    }
+    
+    // add card
+    public static void addCard(AbstractCard card) {
+    	switch (card.color) {
+    	case RED:
+    		redToAdd.add(card);
+    		break;
+    	case GREEN:
+    		greenToAdd.add(card);
+    		break;
+    	case COLORLESS:
+    		colorlessToAdd.add(card);
+    		break;
+    	case CURSE:
+    		curseToAdd.add(card);
+    		break;
+    	}
+    }
+    
+    // remove card
+    public static void removeCard(String card, CardColor color) {
+    	switch (color) {
+    	case RED:
+    		redToRemove.add(card);
+    		break;
+    	case GREEN:
+    		greenToRemove.add(card);
+    		break;
+    	case COLORLESS:
+    		colorlessToRemove.add(card);
+    		break;
+    	case CURSE:
+    		curseToRemove.add(card);
+    		break;
+    	}
     }
 
     //
@@ -650,6 +708,11 @@ public class BaseMod {
         }
         
         return null;
+    }
+    
+    // setPrivateStatic - modify private static variables
+    public static void setPrivateStatic(Class objClass, String fieldName, Object newValue) {
+    	setPrivateStaticFinal(objClass, fieldName, newValue);
     }
     
     // setPrivateStaticFinal - modify (private) static (final) variables

--- a/src/main/java/basemod/interfaces/PostCreateIroncladStartingDeckSubscriber.java
+++ b/src/main/java/basemod/interfaces/PostCreateIroncladStartingDeckSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface PostCreateIroncladStartingDeckSubscriber extends PostCreateStartingDeckSubscriber {
+	
+}

--- a/src/main/java/basemod/interfaces/PostCreateIroncladStartingRelicsSubscriber.java
+++ b/src/main/java/basemod/interfaces/PostCreateIroncladStartingRelicsSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface PostCreateIroncladStartingRelicsSubscriber extends PostCreateStartingRelicsSubscriber {
+
+}

--- a/src/main/java/basemod/interfaces/PostCreateSilentStartingDeckSubscriber.java
+++ b/src/main/java/basemod/interfaces/PostCreateSilentStartingDeckSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface PostCreateSilentStartingDeckSubscriber extends PostCreateStartingDeckSubscriber {
+
+}

--- a/src/main/java/basemod/interfaces/PostCreateSilentStartingRelicsSubscriber.java
+++ b/src/main/java/basemod/interfaces/PostCreateSilentStartingRelicsSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface PostCreateSilentStartingRelicsSubscriber extends PostCreateStartingRelicsSubscriber {
+
+}

--- a/src/main/java/basemod/interfaces/PostCreateStartingDeckSubscriber.java
+++ b/src/main/java/basemod/interfaces/PostCreateStartingDeckSubscriber.java
@@ -1,0 +1,7 @@
+package basemod.interfaces;
+
+import java.util.ArrayList;
+
+public interface PostCreateStartingDeckSubscriber {
+	boolean receivePostCreateStartingDeck(ArrayList<String> addCardsToMe);
+}

--- a/src/main/java/basemod/interfaces/PostCreateStartingRelicsSubscriber.java
+++ b/src/main/java/basemod/interfaces/PostCreateStartingRelicsSubscriber.java
@@ -1,0 +1,7 @@
+package basemod.interfaces;
+
+import java.util.ArrayList;
+
+public interface PostCreateStartingRelicsSubscriber {
+	boolean receivePostCreateStartingRelics(ArrayList<String> addRelicsToMe);
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/PostInitializeStarterDeckHook.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/PostInitializeStarterDeckHook.java
@@ -1,0 +1,19 @@
+package basemod.patches.com.megacrit.cardcrawl.characters.AbstractPlayer;
+
+import basemod.BaseMod;
+
+import java.util.ArrayList;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+
+@SpirePatch(cls="com.megacrit.cardcrawl.characters.AbstractPlayer", method="initializeStarterDeck")
+public class PostInitializeStarterDeckHook {
+    @SpireInsertPatch(loc=246, localvars={"cards"})
+    public static void Insert(Object mObj, Object cardsObj) {
+    	AbstractPlayer  me = (AbstractPlayer) mObj;
+    	ArrayList<String> theCards = (ArrayList<String>) cardsObj;
+        BaseMod.publishPostCreateStartingDeck(me.chosenClass, theCards);
+    }
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/PostInitializeStarterRelicsHook.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/PostInitializeStarterRelicsHook.java
@@ -1,0 +1,26 @@
+package basemod.patches.com.megacrit.cardcrawl.characters.AbstractPlayer;
+
+import basemod.BaseMod;
+
+import java.util.ArrayList;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.characters.AbstractPlayer.PlayerClass;
+
+@SpirePatch(cls="com.megacrit.cardcrawl.characters.AbstractPlayer", method="initializeStarterRelics", paramtypes={"com.megacrit.cardcrawl.characters.AbstractPlayer$PlayerClass"})
+public class PostInitializeStarterRelicsHook {
+	public static final Logger logger = LogManager.getLogger(BaseMod.class.getName());
+	
+	@SpireInsertPatch(loc=271, localvars={"relics"})
+    public static void Insert(Object mObj, PlayerClass chosenClass, Object relicsObj) {
+    	AbstractPlayer me = (AbstractPlayer) mObj;
+    	ArrayList<String> theRelics = (ArrayList<String>) relicsObj;
+    	logger.info("Adding relics to player");
+        BaseMod.publishPostCreateStartingRelics(me.chosenClass, theRelics);
+    }
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/ColorlessCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/ColorlessCardsPatch.java
@@ -9,7 +9,7 @@ import basemod.BaseMod;
 @SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addColorlessCards")
 public class ColorlessCardsPatch {
 
-    public static void Postfix(Object __obj_instance) {
+    public static void Postfix() {
     	// add new cards
 		for (AbstractCard card : BaseMod.getColorlessCardsToAdd()) {
 			CardLibrary.add(card);

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/ColorlessCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/ColorlessCardsPatch.java
@@ -1,0 +1,25 @@
+package basemod.patches.com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import basemod.BaseMod;
+
+@SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addColorlessCards")
+public class ColorlessCardsPatch {
+
+    public static void Postfix(Object __obj_instance) {
+    	// add new cards
+		for (AbstractCard card : BaseMod.getColorlessCardsToAdd()) {
+			CardLibrary.add(card);
+		}
+		
+		// remove old cards
+		for (String card : BaseMod.getColorlessCardsToRemove()) {
+			CardLibrary.cards.remove(card);
+			CardLibrary.colorlessCards--;
+			CardLibrary.totalCardCount--;
+		}
+    }
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/CurseCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/CurseCardsPatch.java
@@ -11,7 +11,7 @@ import basemod.BaseMod;
 @SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addCurseCards")
 public class CurseCardsPatch {
 
-	public static void Postfix(Object __obj_instance) {
+	public static void Postfix() {
 		// add new cards
 		for (AbstractCard card : BaseMod.getCurseCardsToAdd()) {
 			CardLibrary.add(card);

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/CurseCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/CurseCardsPatch.java
@@ -1,0 +1,30 @@
+package basemod.patches.com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import java.util.HashMap;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import basemod.BaseMod;
+
+@SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addCurseCards")
+public class CurseCardsPatch {
+
+	public static void Postfix(Object __obj_instance) {
+		// add new cards
+		for (AbstractCard card : BaseMod.getCurseCardsToAdd()) {
+			CardLibrary.add(card);
+		}
+		
+		// remove old cards
+		for (String card : BaseMod.getCurseCardsToRemove()) {
+			// for some reason curses is set to private so we use reflection to access it
+			Object cursesObj = BaseMod.getPrivateStatic(CardLibrary.class, "curses");
+			HashMap<String, AbstractCard> curses = (HashMap<String, AbstractCard>) cursesObj;
+			curses.remove(card);
+			CardLibrary.curseCards--;
+			CardLibrary.totalCardCount--;
+		}
+	}
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/GreenCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/GreenCardsPatch.java
@@ -8,7 +8,7 @@ import basemod.BaseMod;
 
 @SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addGreenCards")
 public class GreenCardsPatch {
-	public static void Postfix(Object __obj_instance) {
+	public static void Postfix() {
 		// add new cards
 		for (AbstractCard card : BaseMod.getGreenCardsToAdd()) {
 			CardLibrary.add(card);

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/GreenCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/GreenCardsPatch.java
@@ -1,0 +1,24 @@
+package basemod.patches.com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import basemod.BaseMod;
+
+@SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addGreenCards")
+public class GreenCardsPatch {
+	public static void Postfix(Object __obj_instance) {
+		// add new cards
+		for (AbstractCard card : BaseMod.getGreenCardsToAdd()) {
+			CardLibrary.add(card);
+		}
+		
+		// remove old cards
+		for (String card : BaseMod.getGreenCardsToRemove()) {
+			CardLibrary.cards.remove(card);
+			CardLibrary.greenCards--;
+			CardLibrary.totalCardCount--;
+		}
+	}
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/RedCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/RedCardsPatch.java
@@ -1,0 +1,27 @@
+package basemod.patches.com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
+
+import basemod.BaseMod;
+
+@SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addRedCards")
+public class RedCardsPatch {
+	public static void Postfix(Object __obj_instance) {
+		// add new cards
+		for (AbstractCard card : BaseMod.getRedCardsToAdd()) {
+			CardLibrary.add(card);
+		}
+		
+		System.out.println("About to remove");
+		
+		// remove old cards
+		for (String card : BaseMod.getRedCardsToRemove()) {
+			System.out.println("Removing: " + card);
+			CardLibrary.cards.remove(card);
+			CardLibrary.redCards--;
+			CardLibrary.totalCardCount--;
+		}
+	}
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/RedCardsPatch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/RedCardsPatch.java
@@ -8,7 +8,7 @@ import basemod.BaseMod;
 
 @SpirePatch(cls="com.megacrit.cardcrawl.helpers.CardLibrary", method="addRedCards")
 public class RedCardsPatch {
-	public static void Postfix(Object __obj_instance) {
+	public static void Postfix() {
 		// add new cards
 		for (AbstractCard card : BaseMod.getRedCardsToAdd()) {
 			CardLibrary.add(card);

--- a/src/main/java/com/megacrit/cardcrawl/com.megacrit.cardcrawl.diff
+++ b/src/main/java/com/megacrit/cardcrawl/com.megacrit.cardcrawl.diff
@@ -1,144 +1,6 @@
-diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/helpers/CardLibrary.java com/megacrit/cardcrawl/helpers/CardLibrary.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/helpers/CardLibrary.java	2018-02-11 04:43:45.662469400 -0500
-+++ com/megacrit/cardcrawl/helpers/CardLibrary.java	2018-02-11 09:14:13.692630400 -0500
-@@ -3,6 +3,7 @@
-  */
- package com.megacrit.cardcrawl.helpers;
- 
-+import basemod.BaseMod;
- import com.badlogic.gdx.math.MathUtils;
- import com.megacrit.cardcrawl.cards.AbstractCard;
- import com.megacrit.cardcrawl.cards.colorless.Apotheosis;
-@@ -314,6 +315,16 @@
-         CardLibrary.add(new Warcry());
-         CardLibrary.add(new Whirlwind());
-         CardLibrary.add(new WildStrike());
-+		
-+		// add new cards
-+		for (AbstractCard card : BaseMod.getRedCardsToAdd()) {
-+			CardLibrary.add(card);
-+		}
-+		
-+		// remove old cards
-+		for (AbstractCard card : BaseMod.getRedCardsToRemove()) {
-+			CardLibrary.remove(card);
-+		}
-     }
- 
-     private static void addGreenCards() {
-@@ -392,6 +403,16 @@
-         CardLibrary.add(new Unload());
-         CardLibrary.add(new WellLaidPlans());
-         CardLibrary.add(new WraithForm());
-+		
-+		// add new cards
-+		for (AbstractCard card : BaseMod.getGreenCardsToAdd()) {
-+			CardLibrary.add(card);
-+		}
-+		
-+		// remove old cards
-+		for (AbstractCard card : BaseMod.getGreenCardsToRemove()) {
-+			CardLibrary.remove(card);
-+		}
-     }
- 
-     private static void addColorlessCards() {
-@@ -422,6 +443,16 @@
-         CardLibrary.add(new ThinkingAhead());
-         CardLibrary.add(new Transmutation());
-         CardLibrary.add(new Trip());
-+		
-+		// add new cards
-+		for (AbstractCard card : BaseMod.getColorlessCardsToAdd()) {
-+			CardLibrary.add(card);
-+		}
-+		
-+		// remove old cards
-+		for (AbstractCard card : BaseMod.getColorlessCardsToRemove()) {
-+			CardLibrary.remove(card);
-+		}
-     }
- 
-     private static void addCurseCards() {
-@@ -435,6 +466,16 @@
-         CardLibrary.add(new Parasite());
-         CardLibrary.add(new Regret());
-         CardLibrary.add(new Writhe());
-+		
-+		// add new cards
-+		for (AbstractCard card : BaseMod.getCurseCardsToAdd()) {
-+			CardLibrary.add(card);
-+		}
-+		
-+		// remove old cards
-+		for (AbstractCard card : BaseMod.getCurseCardsToRemove()) {
-+			CardLibrary.remove(card);
-+		}
-     }
- 
-     private static void removeNonFinalizedCards() {
-@@ -514,6 +555,53 @@
-         card.initializeDescription();
-         ++totalCardCount;
-     }
-+	
-+	public static void remove(AbstractCard card) {
-+		// not sure how this will interact with seen cards b/c we're removing
-+		// the cards from the library without removing them from the list of seen
-+		// cards
-+		
-+		// also this will likely break lots of things if cards are removed that are
-+		// used by some of the events that the game runs
-+		
-+		// so in order to avoid crashes modders will need to make sure they remove
-+		// events that refer to the cards that now would be made nonexistent
-+		
-+		// this probably will result in some kind of crash
-+		
-+		switch (card.color) {
-+			case RED: {
-+				--redCards;
-+				break;
-+			}
-+			case GREEN: {
-+				--greenCards;
-+				break;
-+			}
-+			case BLUE: {
-+				--blueCards;
-+				break;
-+			}
-+			case COLORLESS: {
-+				--colorlessCards;
-+				break;
-+			}
-+			case CURSE: {
-+				--curseCards;
-+				break;
-+			}
-+		}
-+		switch (card.color) {
-+			case CURSE: {
-+				curses.remove(card.cardID);
-+				break;
-+			}
-+			default: {
-+				cards.remove(card.cardID);
-+			}
-+		}
-+		--totalCardCount;
-+	}
- 
-     public static AbstractCard getCopy(String key, int upgradeTime) {
-         AbstractCard source = CardLibrary.getCard(key);
-@@ -648,3 +736,4 @@
- 
- }
- 
-+
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/map/MapGenerator.java com/megacrit/cardcrawl/map/MapGenerator.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/map/MapGenerator.java	2018-02-11 04:43:47.409628600 -0500
-+++ com/megacrit/cardcrawl/map/MapGenerator.java	2018-02-11 09:12:41.092509900 -0500
++++ com/megacrit/cardcrawl/map/MapGenerator.java	2018-02-11 10:45:01.375827600 -0500
 @@ -3,28 +3,29 @@
   */
  package com.megacrit.cardcrawl.map;
@@ -244,7 +106,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/map/MapGenerator.java c
              str.append(MapGenerator.paddingGenerator(left_padding_size - String.valueOf(row_num).length()));
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/monsters/MonsterGroup.java com/megacrit/cardcrawl/monsters/MonsterGroup.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/monsters/MonsterGroup.java	2018-02-11 04:43:47.772473400 -0500
-+++ com/megacrit/cardcrawl/monsters/MonsterGroup.java	2018-02-11 09:12:41.108525100 -0500
++++ com/megacrit/cardcrawl/monsters/MonsterGroup.java	2018-02-11 10:45:01.393344700 -0500
 @@ -3,31 +3,28 @@
   */
  package com.megacrit.cardcrawl.monsters;
@@ -381,7 +243,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/monsters/MonsterGroup.j
 -
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/powers/IntangiblePower.java com/megacrit/cardcrawl/powers/IntangiblePower.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/powers/IntangiblePower.java	2018-02-11 04:43:51.336358800 -0500
-+++ com/megacrit/cardcrawl/powers/IntangiblePower.java	2018-02-11 09:12:41.115531600 -0500
++++ com/megacrit/cardcrawl/powers/IntangiblePower.java	2018-02-11 10:45:01.399350100 -0500
 @@ -3,19 +3,15 @@
   */
  package com.megacrit.cardcrawl.powers;
@@ -424,7 +286,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/powers/IntangiblePower.
          if (damage > 0.0f) {
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/CancelButton.java com/megacrit/cardcrawl/ui/buttons/CancelButton.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/CancelButton.java	2018-02-11 04:43:57.511724700 -0500
-+++ com/megacrit/cardcrawl/ui/buttons/CancelButton.java	2018-02-11 09:12:41.125040900 -0500
++++ com/megacrit/cardcrawl/ui/buttons/CancelButton.java	2018-02-11 10:45:01.408358500 -0500
 @@ -3,14 +3,11 @@
   */
  package com.megacrit.cardcrawl.ui.buttons;
@@ -475,7 +337,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/CancelButton
                      }
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java	2018-02-11 04:43:57.633339800 -0500
-+++ com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java	2018-02-11 09:12:41.137052300 -0500
++++ com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java	2018-02-11 10:45:01.421621300 -0500
 @@ -3,32 +3,22 @@
   */
  package com.megacrit.cardcrawl.ui.buttons;
@@ -570,7 +432,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/EndTurnButto
              }
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java	2018-02-11 04:43:57.853549300 -0500
-+++ com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java	2018-02-11 09:12:41.143058000 -0500
++++ com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java	2018-02-11 10:45:01.426125700 -0500
 @@ -3,11 +3,10 @@
   */
  package com.megacrit.cardcrawl.ui.campfire;
@@ -607,7 +469,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/campfire/AbstractCam
  
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java	2018-02-11 04:43:58.018205800 -0500
-+++ com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java	2018-02-11 09:12:41.153068400 -0500
++++ com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java	2018-02-11 10:45:01.435634900 -0500
 @@ -3,20 +3,14 @@
   */
  package com.megacrit.cardcrawl.ui.panels;
@@ -694,7 +556,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DiscardPilePa
 -
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java	2018-02-11 04:43:58.043730000 -0500
-+++ com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java	2018-02-11 09:12:41.162076200 -0500
++++ com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java	2018-02-11 10:45:01.444643000 -0500
 @@ -3,21 +3,15 @@
   */
  package com.megacrit.cardcrawl.ui.panels;
@@ -781,7 +643,7 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DrawPilePanel
 -
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/TopPanel.java com/megacrit/cardcrawl/ui/panels/TopPanel.java
 --- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/TopPanel.java	2018-02-11 04:43:58.229406900 -0500
-+++ com/megacrit/cardcrawl/ui/panels/TopPanel.java	2018-02-11 09:12:41.171586400 -0500
++++ com/megacrit/cardcrawl/ui/panels/TopPanel.java	2018-02-11 10:45:01.455154000 -0500
 @@ -3,6 +3,7 @@
   */
  package com.megacrit.cardcrawl.ui.panels;

--- a/src/main/java/com/megacrit/cardcrawl/com.megacrit.cardcrawl.diff
+++ b/src/main/java/com/megacrit/cardcrawl/com.megacrit.cardcrawl.diff
@@ -1,6 +1,144 @@
+diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/helpers/CardLibrary.java com/megacrit/cardcrawl/helpers/CardLibrary.java
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/helpers/CardLibrary.java	2018-02-11 04:43:45.662469400 -0500
++++ com/megacrit/cardcrawl/helpers/CardLibrary.java	2018-02-11 09:14:13.692630400 -0500
+@@ -3,6 +3,7 @@
+  */
+ package com.megacrit.cardcrawl.helpers;
+ 
++import basemod.BaseMod;
+ import com.badlogic.gdx.math.MathUtils;
+ import com.megacrit.cardcrawl.cards.AbstractCard;
+ import com.megacrit.cardcrawl.cards.colorless.Apotheosis;
+@@ -314,6 +315,16 @@
+         CardLibrary.add(new Warcry());
+         CardLibrary.add(new Whirlwind());
+         CardLibrary.add(new WildStrike());
++		
++		// add new cards
++		for (AbstractCard card : BaseMod.getRedCardsToAdd()) {
++			CardLibrary.add(card);
++		}
++		
++		// remove old cards
++		for (AbstractCard card : BaseMod.getRedCardsToRemove()) {
++			CardLibrary.remove(card);
++		}
+     }
+ 
+     private static void addGreenCards() {
+@@ -392,6 +403,16 @@
+         CardLibrary.add(new Unload());
+         CardLibrary.add(new WellLaidPlans());
+         CardLibrary.add(new WraithForm());
++		
++		// add new cards
++		for (AbstractCard card : BaseMod.getGreenCardsToAdd()) {
++			CardLibrary.add(card);
++		}
++		
++		// remove old cards
++		for (AbstractCard card : BaseMod.getGreenCardsToRemove()) {
++			CardLibrary.remove(card);
++		}
+     }
+ 
+     private static void addColorlessCards() {
+@@ -422,6 +443,16 @@
+         CardLibrary.add(new ThinkingAhead());
+         CardLibrary.add(new Transmutation());
+         CardLibrary.add(new Trip());
++		
++		// add new cards
++		for (AbstractCard card : BaseMod.getColorlessCardsToAdd()) {
++			CardLibrary.add(card);
++		}
++		
++		// remove old cards
++		for (AbstractCard card : BaseMod.getColorlessCardsToRemove()) {
++			CardLibrary.remove(card);
++		}
+     }
+ 
+     private static void addCurseCards() {
+@@ -435,6 +466,16 @@
+         CardLibrary.add(new Parasite());
+         CardLibrary.add(new Regret());
+         CardLibrary.add(new Writhe());
++		
++		// add new cards
++		for (AbstractCard card : BaseMod.getCurseCardsToAdd()) {
++			CardLibrary.add(card);
++		}
++		
++		// remove old cards
++		for (AbstractCard card : BaseMod.getCurseCardsToRemove()) {
++			CardLibrary.remove(card);
++		}
+     }
+ 
+     private static void removeNonFinalizedCards() {
+@@ -514,6 +555,53 @@
+         card.initializeDescription();
+         ++totalCardCount;
+     }
++	
++	public static void remove(AbstractCard card) {
++		// not sure how this will interact with seen cards b/c we're removing
++		// the cards from the library without removing them from the list of seen
++		// cards
++		
++		// also this will likely break lots of things if cards are removed that are
++		// used by some of the events that the game runs
++		
++		// so in order to avoid crashes modders will need to make sure they remove
++		// events that refer to the cards that now would be made nonexistent
++		
++		// this probably will result in some kind of crash
++		
++		switch (card.color) {
++			case RED: {
++				--redCards;
++				break;
++			}
++			case GREEN: {
++				--greenCards;
++				break;
++			}
++			case BLUE: {
++				--blueCards;
++				break;
++			}
++			case COLORLESS: {
++				--colorlessCards;
++				break;
++			}
++			case CURSE: {
++				--curseCards;
++				break;
++			}
++		}
++		switch (card.color) {
++			case CURSE: {
++				curses.remove(card.cardID);
++				break;
++			}
++			default: {
++				cards.remove(card.cardID);
++			}
++		}
++		--totalCardCount;
++	}
+ 
+     public static AbstractCard getCopy(String key, int upgradeTime) {
+         AbstractCard source = CardLibrary.getCard(key);
+@@ -648,3 +736,4 @@
+ 
+ }
+ 
++
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/map/MapGenerator.java com/megacrit/cardcrawl/map/MapGenerator.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/map/MapGenerator.java	2018-02-08 20:13:23.981675900 -0800
-+++ com/megacrit/cardcrawl/map/MapGenerator.java	2018-02-01 19:41:29.043025200 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/map/MapGenerator.java	2018-02-11 04:43:47.409628600 -0500
++++ com/megacrit/cardcrawl/map/MapGenerator.java	2018-02-11 09:12:41.092509900 -0500
 @@ -3,28 +3,29 @@
   */
  package com.megacrit.cardcrawl.map;
@@ -105,8 +243,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/map/MapGenerator.java c
              str.append("\n").append(row_num).append(" ");
              str.append(MapGenerator.paddingGenerator(left_padding_size - String.valueOf(row_num).length()));
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/monsters/MonsterGroup.java com/megacrit/cardcrawl/monsters/MonsterGroup.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/monsters/MonsterGroup.java	2018-02-08 20:13:24.265449300 -0800
-+++ com/megacrit/cardcrawl/monsters/MonsterGroup.java	2018-02-03 00:24:09.041768100 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/monsters/MonsterGroup.java	2018-02-11 04:43:47.772473400 -0500
++++ com/megacrit/cardcrawl/monsters/MonsterGroup.java	2018-02-11 09:12:41.108525100 -0500
 @@ -3,31 +3,28 @@
   */
  package com.megacrit.cardcrawl.monsters;
@@ -242,8 +380,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/monsters/MonsterGroup.j
  }
 -
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/powers/IntangiblePower.java com/megacrit/cardcrawl/powers/IntangiblePower.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/powers/IntangiblePower.java	2018-02-08 20:13:26.086697800 -0800
-+++ com/megacrit/cardcrawl/powers/IntangiblePower.java	2018-02-01 19:41:29.051562700 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/powers/IntangiblePower.java	2018-02-11 04:43:51.336358800 -0500
++++ com/megacrit/cardcrawl/powers/IntangiblePower.java	2018-02-11 09:12:41.115531600 -0500
 @@ -3,19 +3,15 @@
   */
  package com.megacrit.cardcrawl.powers;
@@ -285,8 +423,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/powers/IntangiblePower.
      public float atDamageReceive(float damage, DamageInfo.DamageType type) {
          if (damage > 0.0f) {
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/CancelButton.java com/megacrit/cardcrawl/ui/buttons/CancelButton.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/CancelButton.java	2018-02-08 20:13:30.163113200 -0800
-+++ com/megacrit/cardcrawl/ui/buttons/CancelButton.java	2018-02-01 19:41:29.054065100 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/CancelButton.java	2018-02-11 04:43:57.511724700 -0500
++++ com/megacrit/cardcrawl/ui/buttons/CancelButton.java	2018-02-11 09:12:41.125040900 -0500
 @@ -3,14 +3,11 @@
   */
  package com.megacrit.cardcrawl.ui.buttons;
@@ -336,8 +474,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/CancelButton
                          return;
                      }
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java	2018-02-08 20:13:30.322266400 -0800
-+++ com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java	2018-02-08 20:21:33.369300000 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java	2018-02-11 04:43:57.633339800 -0500
++++ com/megacrit/cardcrawl/ui/buttons/EndTurnButton.java	2018-02-11 09:12:41.137052300 -0500
 @@ -3,32 +3,22 @@
   */
  package com.megacrit.cardcrawl.ui.buttons;
@@ -431,8 +569,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/buttons/EndTurnButto
                  this.hitbox.render(sb);
              }
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java	2018-02-08 20:13:30.433873200 -0800
-+++ com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java	2018-02-01 19:41:29.060583000 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java	2018-02-11 04:43:57.853549300 -0500
++++ com/megacrit/cardcrawl/ui/campfire/AbstractCampfireOption.java	2018-02-11 09:12:41.143058000 -0500
 @@ -3,11 +3,10 @@
   */
  package com.megacrit.cardcrawl.ui.campfire;
@@ -468,8 +606,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/campfire/AbstractCam
      }
  
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java	2018-02-08 20:13:30.518955100 -0800
-+++ com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java	2018-02-08 20:22:04.035360200 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java	2018-02-11 04:43:58.018205800 -0500
++++ com/megacrit/cardcrawl/ui/panels/DiscardPilePanel.java	2018-02-11 09:12:41.153068400 -0500
 @@ -3,20 +3,14 @@
   */
  package com.megacrit.cardcrawl.ui.panels;
@@ -555,8 +693,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DiscardPilePa
  }
 -
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java	2018-02-08 20:13:30.537973500 -0800
-+++ com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java	2018-02-08 20:22:04.040865300 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java	2018-02-11 04:43:58.043730000 -0500
++++ com/megacrit/cardcrawl/ui/panels/DrawPilePanel.java	2018-02-11 09:12:41.162076200 -0500
 @@ -3,21 +3,15 @@
   */
  package com.megacrit.cardcrawl.ui.panels;
@@ -642,8 +780,8 @@ diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/DrawPilePanel
  }
 -
 diff -ru ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/TopPanel.java com/megacrit/cardcrawl/ui/panels/TopPanel.java
---- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/TopPanel.java	2018-02-08 20:13:30.672602800 -0800
-+++ com/megacrit/cardcrawl/ui/panels/TopPanel.java	2018-02-08 20:33:59.382660600 -0800
+--- ../../../_lib/decompiled/com/megacrit/cardcrawl/ui/panels/TopPanel.java	2018-02-11 04:43:58.229406900 -0500
++++ com/megacrit/cardcrawl/ui/panels/TopPanel.java	2018-02-11 09:12:41.171586400 -0500
 @@ -3,6 +3,7 @@
   */
  package com.megacrit.cardcrawl.ui.panels;


### PR DESCRIPTION
This change doesn't work as intended right now and I'm posting this here in case anyone has a bit more insight into how bytecode patching works so I can fix it. Right now everything in the patches for CardLibrary look right but the Patcher refuses to patch any of the methods in CardLibrary.

I've worked on debugging it and I think the issue is that the methods are static but I can't see why javassist wouldn't be able to update static methods. Any ideas?